### PR TITLE
Change main scenario and add exception 4

### DIFF
--- a/usecases/supporting/ReservedAirspace.md
+++ b/usecases/supporting/ReservedAirspace.md
@@ -2,7 +2,7 @@
 
 **Description**
 
-All UAVs must receive airspace authorization prior to commencing flight to a waypoint. Collisions are prevented through a multi-faceted approach of collision avvoidance for unplanned violations of minimum separation distance, and just-in-time airspace reservations from the UAVs current coordinates to a target coordinate.
+All UAVs must receive airspace authorization prior to commencing flight to a waypoint. Collisions are prevented through a multi-faceted approach of collision avoidance for unplanned violations of minimum separation distance, and just-in-time airspace reservations from the UAVs current coordinates to a target coordinate.
 
 **Primary Actor**
 
@@ -33,17 +33,17 @@ Failure end condition:
 
 **Trigger**
 
-The UAV needs to fly to a waypoint.
+The UAV needs to fly to a waypoint or needs some space to perform an action.
 
 ## Main Success Scenario
 
-1. The UAV requests permission from ATC to fly its target waypoint.
-2. ATC calculates the airspace needed for the flight.
+1. The UAV calculates the airspace needed for its next action.
+2. The UAV requests permission from ATC to reserve the airspace identified.
 3. ATC determines that the airspace can be reserved.
-4. ATC reserves the airspace for a given time interval.
-5. ATC assigns the UAV permission to fly to the waypoint.
-6. The UAV arrives at the waypoint and notifies ATC.
-7. ATC releases the airspace.
+4. ATC reserves the airspace.
+5. ATC releases any airspace reservations previously held by the UAV.
+6. ATC grants the UAV an exclusive lease of the airspace.
+7. The UAV completes its action and goes to step 1.
 
 ## Exceptions
 
@@ -59,7 +59,26 @@ The UAV needs to fly to a waypoint.
    * 3.1 ATC denies the request for airspace.
    * 3.2 The UAV waits for a random time interval (< 5 seconds) and repeats its request for airspace.
    * 3.3 The UAV repeats step 3.2 until it receives airspace authorization at which point the use case continues with steps 4-7.
-   
-4. In step 1, the direct path from the UAV's current waypoint to the requested waypoint passes through restricted airspace.
-   * tbd (who is responsible for proposing a new route?)
+
+4. (Alternatively instead of #2 or #3) In step 3, ATC determines that the airspace is not currently available.
+   * 4.1 ATC finds all reservations held by other UAVs that share some altitude with the requested airspace.
+   * 4.2 ATC finds all restricted airspace that shares some altitude and is less than 1000 meters from the requested airspace.
+   * 4.2 ATC denies the request for airspace and attaches both the list of other reservations and the list of restricted airspaces.
+   * 4.3 The UAV analyzes the attached lists and selects an alternative action among:
+      * 4.3.0 If the action is impossible because of restricted airspace
+         * 4.3.0.1 TBD
+      * 4.3.1 If the next action is to fly to a waypoint, and the UAV determines that meaningful progress is possible then
+         * 4.3.1.1 The UAV picks a new waypoint that moves it closer to the target.
+         * 4.3.1.2 The use case continues at step 1.
+      * 4.3.2 If progress on the next action is possible, then
+         * 4.3.2.1 The UAV decides on a new next action.
+         * 4.3.2.2 The use case continues at step 1.
+      * 4.3.3 If progress is not possible, and the UAV is in the air, then
+         * 4.3.3.1 The UAV requests a small amount of airspace to wait within. This new airspace must fit inside the airspace that the UAV has already reserved. The UAV is guaranteed to get a lease on the new airspace in case it fits within its current airspace.
+         * 4.3.3.2 The UAV waits for a random time interval (< 5 seconds) and repeats its request for airspace.
+         * 4.3.3.3 The use case continues at step 3.
+      * 4.3.4 If the UAV is on the ground, awaiting takeoff, and progress is not possible, then
+         * 4.3.4.1 The UAV waits for a random time interval (< 5 seconds) and repeats its request for airspace.
+         * 4.3.4.2 The use case continues at step 3.
+
    


### PR DESCRIPTION
I made some changes to the Reserved Airspace use case. I described the ATC as I understood it during our meetings. It's very similar to what's written but there are some subtle differences. Most notably, the ATC grants leases to airspace and the UAV holds onto its lease until the ATC grants it a replacement lease. I also added an alternative exception case for when ATC cannot grant the UAV a lease. The new exception case has the UAV decide on a next action by looking at the other leases and nearby restricted fly zones. In the worst case, the UAV follows the procedure described in exception #3. I like exception #3 because it's simple and we can start there before we grow into something more. 

Here is a summary of changes (taken from the commit message):
- Change the main success scenario. Now the ATC leases airspace to UAVs. The UAV holds the lease until the ATC leases it some replacement airspace.
- Add exception 4. In case the ATC cannot grant a lease to the UAV, the ATC attaches a list of other reservations and a list of relevant airspace restrictions. The UAV uses these lists to decide on its next steps.